### PR TITLE
Fix erroneous use of "pass" which is not a bash keyword.

### DIFF
--- a/cocci/startcocci_freebsd.sh
+++ b/cocci/startcocci_freebsd.sh
@@ -12,10 +12,8 @@ else
 	echo Make outcome dir...
 fi
 
-if test -d ${testdir}
-then 
-	pass
-else
+if ! test -d ${testdir}
+then
 	mkdir ${testdir}
 	echo Make  testdir...
 fi

--- a/cocci/startcocci_linux.sh
+++ b/cocci/startcocci_linux.sh
@@ -12,10 +12,8 @@ else
 	echo Make outcome dir...
 fi
 
-if test -d ${testdir}
+if ! test -d ${testdir}
 then 
-	pass
-else
 	mkdir ${testdir}
 	echo Make  testdir...
 fi


### PR DESCRIPTION
In bash, an empty operation is represented by a colon (:).
Refactored if statements to not include an unnecessary empty operation.