### PR TITLE
Refactor coccinelle patterns

### DIFF
--- a/cocci/pattern_match_freebsd.cocci
+++ b/cocci/pattern_match_freebsd.cocci
@@ -16,11 +16,10 @@ def print_and_log(filename,first,second,count):
 	logfile.write("--first fetch: line " + str(first) + "\n")
 	logfile.write("--second fetch: line " + str(second) + "\n")
 	logfile.write("-------------------------------\n")
-	
 	logfile.close()
 
 def post_match_process(p1,p2,src,ptr):
-  global count
+	global count
 	filename = p1[0].file
 	first = p1[0].line
 	second = p2[0].line
@@ -31,7 +30,7 @@ def post_match_process(p1,p2,src,ptr):
 	# remove loop case, first and second fetch are not supposed to be in the same line.
 	if first == second: 
 		return
-	# remove reverse loop case, where first fetch behand second fetch but in last loop .
+	# remove reverse loop case, where first fetch behand second fetch but in last loop.
 	if int(first) > int(second):
 		return
 	# remove case of get_user(a, src++) or get_user(a, src + 4)
@@ -46,15 +45,13 @@ def post_match_process(p1,p2,src,ptr):
 	if ptr_str.find("-") != -1 and ptr_str.find("->") == -1:
 		return
 	# remove false matching of src ===> (int*)src,
-  # but leave function call like u64_to_uptr(ctl_sccb.sccb)
+	# but leave function call like u64_to_uptr(ctl_sccb.sccb)
 	if src_str.find("(") == 0 or ptr_str.find("(") == 0:
 		return
 
 	print_and_log(filename, first, second, count)
-  count += 1
-
-	return count
-
+	count += 1
+	return
 
 //---------------------Pattern Matching Rules-----------------------------------
 //----------------------------------- case 1: normal case without src assignment
@@ -122,9 +119,8 @@ s1 << rule1.src;
 print "src1:", str(s1)
 if p11 and p12:
 	coccilib.report.print_report(p11[0],"rule1 First fetch")
-	coccilib.report.print_report(p12[0],"rule1 Second fetch")
-	
-  post_match_process(p11, p12, s1, s1, count)
+	coccilib.report.print_report(p12[0],"rule1 Second fetch")	
+	post_match_process(p11, p12, s1, s1, count)
 
 //--------------------------------------- case 2: ptr = src at beginning, ptr first
 @ rule2 disable drop_cast exists @
@@ -200,7 +196,6 @@ if p21 and p22:
 	coccilib.report.print_report(p21[0],"rule2 First fetch")
 	coccilib.report.print_report(p22[0],"rule2 Second fetch")
 	post_match_process(p21, p22, s2, p2, count)
-
 
 //--------------------------------------- case 3: ptr = src at beginning, src first
 @ rule3 disable drop_cast exists @
@@ -438,7 +433,6 @@ if p51 and p52:
 	coccilib.report.print_report(p51[0],"rule5 First fetch")
 	coccilib.report.print_report(p52[0],"rule5 Second fetch")
 	post_match_process(p51, p52, s5, e5, count)
-
 
 //----------------------------------- case 6: first element, then ptr, copy from pointer
 @ rule6 disable drop_cast exists @

--- a/cocci/pattern_match_freebsd.cocci
+++ b/cocci/pattern_match_freebsd.cocci
@@ -5,7 +5,7 @@
 
 count = 0
 
-def print_and_log(filename,first,second,count):
+def print_and_log(filename, first, second, count):
 	print "No. ", count, " file: ", filename
 	print "--first fetch: line ",first
 	print "--second fetch: line ",second
@@ -18,7 +18,7 @@ def print_and_log(filename,first,second,count):
 	logfile.write("-------------------------------\n")
 	logfile.close()
 
-def post_match_process(p1,p2,src,ptr):
+def post_match_process(p1, p2, src, ptr):
 	global count
 	filename = p1[0].file
 	first = p1[0].line
@@ -49,7 +49,7 @@ def post_match_process(p1,p2,src,ptr):
 	if src_str.find("(") == 0 or ptr_str.find("(") == 0:
 		return
 
-	print_and_log(filename, first, second, count)
+	print_and_log(filename, first, second, str(count))
 	count += 1
 	return
 
@@ -120,7 +120,7 @@ print "src1:", str(s1)
 if p11 and p12:
 	coccilib.report.print_report(p11[0],"rule1 First fetch")
 	coccilib.report.print_report(p12[0],"rule1 Second fetch")	
-	post_match_process(p11, p12, s1, s1, count)
+	post_match_process(p11, p12, s1, s1)
 
 //--------------------------------------- case 2: ptr = src at beginning, ptr first
 @ rule2 disable drop_cast exists @
@@ -195,7 +195,7 @@ print "ptr2:", str(p2)
 if p21 and p22:
 	coccilib.report.print_report(p21[0],"rule2 First fetch")
 	coccilib.report.print_report(p22[0],"rule2 Second fetch")
-	post_match_process(p21, p22, s2, p2, count)
+	post_match_process(p21, p22, s2, p2)
 
 //--------------------------------------- case 3: ptr = src at beginning, src first
 @ rule3 disable drop_cast exists @
@@ -270,7 +270,7 @@ print "ptr3:", str(p3)
 if p31 and p32:
 	coccilib.report.print_report(p31[0],"rule3 First fetch")
 	coccilib.report.print_report(p32[0],"rule3 Second fetch")
-	post_match_process(p31, p32, s3, p3, count)
+	post_match_process(p31, p32, s3, p3)
 
 //----------------------------------- case 4: ptr = src at middle
 
@@ -355,7 +355,7 @@ print "ptr4:", str(p4)
 if p41 and p42:
 	coccilib.report.print_report(p41[0],"rule4 First fetch")
 	coccilib.report.print_report(p42[0],"rule4 Second fetch")
-	post_match_process(p41, p42, s4, p4, count)
+	post_match_process(p41, p42, s4, p4)
 
 //----------------------------------- case 5: first element, then ptr, copy from structure
 @ rule5 disable drop_cast exists @
@@ -432,7 +432,7 @@ print "e5:", str(e5)
 if p51 and p52:
 	coccilib.report.print_report(p51[0],"rule5 First fetch")
 	coccilib.report.print_report(p52[0],"rule5 Second fetch")
-	post_match_process(p51, p52, s5, e5, count)
+	post_match_process(p51, p52, s5, e5)
 
 //----------------------------------- case 6: first element, then ptr, copy from pointer
 @ rule6 disable drop_cast exists @
@@ -507,4 +507,4 @@ print "e6:", str(e6)
 if p61 and p62:
 	coccilib.report.print_report(p61[0],"rule6 First fetch")
 	coccilib.report.print_report(p62[0],"rule6 Second fetch")
-	post_match_process(p61, p62, s6, e6, count)
+	post_match_process(p61, p62, s6, e6)

--- a/cocci/pattern_match_freebsd.cocci
+++ b/cocci/pattern_match_freebsd.cocci
@@ -1,11 +1,11 @@
 //define global variable
 @initialize:python@
-count << virtual.count;
 @@
 #-----------------------------Post Matching Process------------------------------
-def print_and_log(filename,first,second,count):
-	
 
+count = 0
+
+def print_and_log(filename,first,second,count):
 	print "No. ", count, " file: ", filename
 	print "--first fetch: line ",first
 	print "--second fetch: line ",second
@@ -19,18 +19,14 @@ def print_and_log(filename,first,second,count):
 	
 	logfile.close()
 
-def post_match_process(p1,p2,src,ptr,count):
-
+def post_match_process(p1,p2,src,ptr):
+  global count
 	filename = p1[0].file
 	first = p1[0].line
 	second = p2[0].line
 
 	src_str = str(src)
 	ptr_str = str(ptr)
-	#print "src1:", src_str
-	#print "src2:", ptr_str
-	#print "first:", first
-	#print "second:", second
 
 	# remove loop case, first and second fetch are not supposed to be in the same line.
 	if first == second: 
@@ -49,16 +45,13 @@ def post_match_process(p1,p2,src,ptr,count):
 		return
 	if ptr_str.find("-") != -1 and ptr_str.find("->") == -1:
 		return
-	# remove false matching of src ===> (int*)src , but leave function call like u64_to_uptr(ctl_sccb.sccb)
+	# remove false matching of src ===> (int*)src,
+  # but leave function call like u64_to_uptr(ctl_sccb.sccb)
 	if src_str.find("(") == 0 or ptr_str.find("(") == 0:
 		return
 
-	if count:
-		count = str(int(count) + 1)
-	else:
-		count = "1"
-
 	print_and_log(filename, first, second, count)
+  count += 1
 
 	return count
 
@@ -131,11 +124,7 @@ if p11 and p12:
 	coccilib.report.print_report(p11[0],"rule1 First fetch")
 	coccilib.report.print_report(p12[0],"rule1 Second fetch")
 	
-	ret = post_match_process(p11, p12, s1, s1, count)
-	if ret: 
-		count = ret
-
-
+  post_match_process(p11, p12, s1, s1, count)
 
 //--------------------------------------- case 2: ptr = src at beginning, ptr first
 @ rule2 disable drop_cast exists @
@@ -210,9 +199,8 @@ print "ptr2:", str(p2)
 if p21 and p22:
 	coccilib.report.print_report(p21[0],"rule2 First fetch")
 	coccilib.report.print_report(p22[0],"rule2 Second fetch")
-	ret = post_match_process(p21, p22, s2, p2, count)
-	if ret: 
-		count = ret
+	post_match_process(p21, p22, s2, p2, count)
+
 
 //--------------------------------------- case 3: ptr = src at beginning, src first
 @ rule3 disable drop_cast exists @
@@ -287,9 +275,7 @@ print "ptr3:", str(p3)
 if p31 and p32:
 	coccilib.report.print_report(p31[0],"rule3 First fetch")
 	coccilib.report.print_report(p32[0],"rule3 Second fetch")
-	ret = post_match_process(p31, p32, s3, p3, count)
-	if ret: 
-		count = ret
+	post_match_process(p31, p32, s3, p3, count)
 
 //----------------------------------- case 4: ptr = src at middle
 
@@ -374,9 +360,7 @@ print "ptr4:", str(p4)
 if p41 and p42:
 	coccilib.report.print_report(p41[0],"rule4 First fetch")
 	coccilib.report.print_report(p42[0],"rule4 Second fetch")
-	ret = post_match_process(p41, p42, s4, p4, count)
-	if ret: 
-		count = ret
+	post_match_process(p41, p42, s4, p4, count)
 
 //----------------------------------- case 5: first element, then ptr, copy from structure
 @ rule5 disable drop_cast exists @
@@ -453,9 +437,7 @@ print "e5:", str(e5)
 if p51 and p52:
 	coccilib.report.print_report(p51[0],"rule5 First fetch")
 	coccilib.report.print_report(p52[0],"rule5 Second fetch")
-	ret = post_match_process(p51, p52, s5, e5, count)
-	if ret: 
-		count = ret
+	post_match_process(p51, p52, s5, e5, count)
 
 
 //----------------------------------- case 6: first element, then ptr, copy from pointer
@@ -531,18 +513,4 @@ print "e6:", str(e6)
 if p61 and p62:
 	coccilib.report.print_report(p61[0],"rule6 First fetch")
 	coccilib.report.print_report(p62[0],"rule6 Second fetch")
-	ret = post_match_process(p61, p62, s6, e6, count)
-	if ret: 
-		count = ret
-
-
-
-
-
-
-
-
-
-
-
-
+	post_match_process(p61, p62, s6, e6, count)

--- a/cocci/pattern_match_linux.cocci
+++ b/cocci/pattern_match_linux.cocci
@@ -16,11 +16,10 @@ def print_and_log(filename,first,second,count):
 	logfile.write("--first fetch: line " + str(first) + "\n")
 	logfile.write("--second fetch: line " + str(second) + "\n")
 	logfile.write("-------------------------------\n")
-	
 	logfile.close()
 
 def post_match_process(p1,p2,src,ptr):
-  global count
+	global count
 	filename = p1[0].file
 	first = p1[0].line
 	second = p2[0].line
@@ -46,15 +45,13 @@ def post_match_process(p1,p2,src,ptr):
 	if ptr_str.find("-") != -1 and ptr_str.find("->") == -1:
 		return
 	# remove false matching of src ===> (int*)src,
-  # but leave function call like u64_to_uptr(ctl_sccb.sccb)
+	# but leave function call like u64_to_uptr(ctl_sccb.sccb)
 	if src_str.find("(") == 0 or ptr_str.find("(") == 0:
 		return
 
 	print_and_log(filename, first, second, count)
-  count += 1
-  return
-	
-
+	count += 1
+	return
 
 //---------------------Pattern Matching Rules-----------------------------------
 //----------------------------------- case 1: normal case without src assignment
@@ -123,7 +120,6 @@ print "src1:", str(s1)
 if p11 and p12:
 	coccilib.report.print_report(p11[0],"rule1 First fetch")
 	coccilib.report.print_report(p12[0],"rule1 Second fetch")
-
 	post_match_process(p11, p12, s1, s1, count)
 
 //--------------------------------------- case 2: ptr = src at beginning, ptr first
@@ -275,6 +271,7 @@ if p31 and p32:
 	coccilib.report.print_report(p31[0],"rule3 First fetch")
 	coccilib.report.print_report(p32[0],"rule3 Second fetch")
 	post_match_process(p31, p32, s3, p3, count)
+
 //----------------------------------- case 4: ptr = src at middle
 
 @ rule4 disable drop_cast exists @
@@ -436,7 +433,6 @@ if p51 and p52:
 	coccilib.report.print_report(p51[0],"rule5 First fetch")
 	coccilib.report.print_report(p52[0],"rule5 Second fetch")
 	post_match_process(p51, p52, s5, e5, count)
-
 
 //----------------------------------- case 6: first element, then ptr, copy from pointer
 @ rule6 disable drop_cast exists @

--- a/cocci/pattern_match_linux.cocci
+++ b/cocci/pattern_match_linux.cocci
@@ -5,7 +5,7 @@
 
 count = 0
 
-def print_and_log(filename,first,second,count):
+def print_and_log(filename, first, second, count):
 	print "No. ", count, " file: ", filename
 	print "--first fetch: line ",first
 	print "--second fetch: line ",second
@@ -18,7 +18,7 @@ def print_and_log(filename,first,second,count):
 	logfile.write("-------------------------------\n")
 	logfile.close()
 
-def post_match_process(p1,p2,src,ptr):
+def post_match_process(p1, p2, src, ptr):
 	global count
 	filename = p1[0].file
 	first = p1[0].line
@@ -49,7 +49,7 @@ def post_match_process(p1,p2,src,ptr):
 	if src_str.find("(") == 0 or ptr_str.find("(") == 0:
 		return
 
-	print_and_log(filename, first, second, count)
+	print_and_log(filename, first, second, str(count))
 	count += 1
 	return
 
@@ -120,7 +120,7 @@ print "src1:", str(s1)
 if p11 and p12:
 	coccilib.report.print_report(p11[0],"rule1 First fetch")
 	coccilib.report.print_report(p12[0],"rule1 Second fetch")
-	post_match_process(p11, p12, s1, s1, count)
+	post_match_process(p11, p12, s1, s1)
 
 //--------------------------------------- case 2: ptr = src at beginning, ptr first
 @ rule2 disable drop_cast exists @
@@ -195,7 +195,7 @@ print "ptr2:", str(p2)
 if p21 and p22:
 	coccilib.report.print_report(p21[0],"rule2 First fetch")
 	coccilib.report.print_report(p22[0],"rule2 Second fetch")
-	post_match_process(p21, p22, s2, p2, count)
+	post_match_process(p21, p22, s2, p2)
 
 //--------------------------------------- case 3: ptr = src at beginning, src first
 @ rule3 disable drop_cast exists @
@@ -270,7 +270,7 @@ print "ptr3:", str(p3)
 if p31 and p32:
 	coccilib.report.print_report(p31[0],"rule3 First fetch")
 	coccilib.report.print_report(p32[0],"rule3 Second fetch")
-	post_match_process(p31, p32, s3, p3, count)
+	post_match_process(p31, p32, s3, p3)
 
 //----------------------------------- case 4: ptr = src at middle
 
@@ -355,7 +355,7 @@ print "ptr4:", str(p4)
 if p41 and p42:
 	coccilib.report.print_report(p41[0],"rule4 First fetch")
 	coccilib.report.print_report(p42[0],"rule4 Second fetch")
-	post_match_process(p41, p42, s4, p4, count)
+	post_match_process(p41, p42, s4, p4)
 
 //----------------------------------- case 5: first element, then ptr, copy from structure
 @ rule5 disable drop_cast exists @
@@ -432,7 +432,7 @@ print "e5:", str(e5)
 if p51 and p52:
 	coccilib.report.print_report(p51[0],"rule5 First fetch")
 	coccilib.report.print_report(p52[0],"rule5 Second fetch")
-	post_match_process(p51, p52, s5, e5, count)
+	post_match_process(p51, p52, s5, e5)
 
 //----------------------------------- case 6: first element, then ptr, copy from pointer
 @ rule6 disable drop_cast exists @
@@ -507,4 +507,4 @@ print "e6:", str(e6)
 if p61 and p62:
 	coccilib.report.print_report(p61[0],"rule6 First fetch")
 	coccilib.report.print_report(p62[0],"rule6 Second fetch")
-	post_match_process(p61, p62, s6, e6, count)
+	post_match_process(p61, p62, s6, e6)

--- a/cocci/pattern_match_linux.cocci
+++ b/cocci/pattern_match_linux.cocci
@@ -1,11 +1,11 @@
 //define global variable
 @initialize:python@
-count << virtual.count;
 @@
 #-----------------------------Post Matching Process------------------------------
-def print_and_log(filename,first,second,count):
-	
 
+count = 0
+
+def print_and_log(filename,first,second,count):
 	print "No. ", count, " file: ", filename
 	print "--first fetch: line ",first
 	print "--second fetch: line ",second
@@ -19,22 +19,19 @@ def print_and_log(filename,first,second,count):
 	
 	logfile.close()
 
-def post_match_process(p1,p2,src,ptr,count):
+def post_match_process(p1,p2,src,ptr):
+  global count
 	filename = p1[0].file
 	first = p1[0].line
 	second = p2[0].line
 
 	src_str = str(src)
 	ptr_str = str(ptr)
-	#print "src1:", src_str
-	#print "src2:", ptr_str
-	#print "first:", first
-	#print "second:", second
 
 	# remove loop case, first and second fetch are not supposed to be in the same line.
 	if first == second: 
 		return
-	# remove reverse loop case, where first fetch behand second fetch but in last loop .
+	# remove reverse loop case, where first fetch behand second fetch but in last loop.
 	if int(first) > int(second):
 		return
 	# remove case of get_user(a, src++) or get_user(a, src + 4)
@@ -48,18 +45,14 @@ def post_match_process(p1,p2,src,ptr,count):
 		return
 	if ptr_str.find("-") != -1 and ptr_str.find("->") == -1:
 		return
-	# remove false matching of src ===> (int*)src , but leave function call like u64_to_uptr(ctl_sccb.sccb)
+	# remove false matching of src ===> (int*)src,
+  # but leave function call like u64_to_uptr(ctl_sccb.sccb)
 	if src_str.find("(") == 0 or ptr_str.find("(") == 0:
 		return
 
-	if count:
-		count = str(int(count) + 1)
-	else:
-		count = "1"
-
 	print_and_log(filename, first, second, count)
-
-	return count
+  count += 1
+  return
 	
 
 
@@ -131,9 +124,7 @@ if p11 and p12:
 	coccilib.report.print_report(p11[0],"rule1 First fetch")
 	coccilib.report.print_report(p12[0],"rule1 Second fetch")
 
-	ret = post_match_process(p11, p12, s1, s1, count)
-	if ret: 
-		count = ret
+	post_match_process(p11, p12, s1, s1, count)
 
 //--------------------------------------- case 2: ptr = src at beginning, ptr first
 @ rule2 disable drop_cast exists @
@@ -208,9 +199,8 @@ print "ptr2:", str(p2)
 if p21 and p22:
 	coccilib.report.print_report(p21[0],"rule2 First fetch")
 	coccilib.report.print_report(p22[0],"rule2 Second fetch")
-	ret = post_match_process(p21, p22, s2, p2, count)
-	if ret: 
-		count = ret
+	post_match_process(p21, p22, s2, p2, count)
+
 //--------------------------------------- case 3: ptr = src at beginning, src first
 @ rule3 disable drop_cast exists @
 identifier func;
@@ -284,9 +274,7 @@ print "ptr3:", str(p3)
 if p31 and p32:
 	coccilib.report.print_report(p31[0],"rule3 First fetch")
 	coccilib.report.print_report(p32[0],"rule3 Second fetch")
-	ret = post_match_process(p31, p32, s3, p3, count)
-	if ret: 
-		count = ret
+	post_match_process(p31, p32, s3, p3, count)
 //----------------------------------- case 4: ptr = src at middle
 
 @ rule4 disable drop_cast exists @
@@ -370,9 +358,8 @@ print "ptr4:", str(p4)
 if p41 and p42:
 	coccilib.report.print_report(p41[0],"rule4 First fetch")
 	coccilib.report.print_report(p42[0],"rule4 Second fetch")
-	ret = post_match_process(p41, p42, s4, p4, count)
-	if ret: 
-		count = ret
+	post_match_process(p41, p42, s4, p4, count)
+
 //----------------------------------- case 5: first element, then ptr, copy from structure
 @ rule5 disable drop_cast exists @
 identifier func, e1;
@@ -448,9 +435,7 @@ print "e5:", str(e5)
 if p51 and p52:
 	coccilib.report.print_report(p51[0],"rule5 First fetch")
 	coccilib.report.print_report(p52[0],"rule5 Second fetch")
-	ret = post_match_process(p51, p52, s5, e5, count)
-	if ret: 
-		count = ret
+	post_match_process(p51, p52, s5, e5, count)
 
 
 //----------------------------------- case 6: first element, then ptr, copy from pointer
@@ -526,9 +511,4 @@ print "e6:", str(e6)
 if p61 and p62:
 	coccilib.report.print_report(p61[0],"rule6 First fetch")
 	coccilib.report.print_report(p62[0],"rule6 Second fetch")
-	ret = post_match_process(p61, p62, s6, e6, count)
-	if ret: 
-		count = ret
-
-
-
+	post_match_process(p61, p62, s6, e6, count)

--- a/cocci/startcocci_freebsd.sh
+++ b/cocci/startcocci_freebsd.sh
@@ -29,7 +29,7 @@ else
 fi
 
 echo Start analyzing...
-spatch -cocci_file pattern_match_freebsd.cocci -D count=0 -dir ${testdir}
+spatch -cocci_file pattern_match_freebsd.cocci -dir ${testdir}
 #--disable-worth-trying-opt
 echo Finished analyzing.
 python copy_files.py

--- a/cocci/startcocci_linux.sh
+++ b/cocci/startcocci_linux.sh
@@ -29,7 +29,7 @@ else
 fi
 
 echo Start analyzing...
-spatch -cocci_file pattern_match_linux.cocci -D count=0 -dir ${testdir}
+spatch -cocci_file pattern_match_linux.cocci -dir ${testdir}
 #--disable-worth-trying-opt
 echo Finished analyzing.
 python copy_files.py


### PR DESCRIPTION
There seems to be a problem with virtual count variable - it is not properly set, which causes errors in numbering of findings.

This change refactors patterns to remove unnecessary virtual variable by introducing a global counter, as well as fixes some minor style issues.